### PR TITLE
enforce jvm version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --javabase=@bazel_tools//tools/jdk:remote_jdk11


### PR DESCRIPTION
Bazel now has a configuration to avoid having to export JAVA_HOME to point to java11.